### PR TITLE
Add !toggledev command, ping all queue'd players when queue reaches 10/10, and move !signup to threads

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -148,6 +148,7 @@ mock_match_data = {
 class BotCommands(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        self.dev_mode = False
 
     # Signup Command
     @commands.command()
@@ -702,6 +703,17 @@ class BotCommands(commands.Cog):
 
         self.bot.captain2 = player_in_queue
         await ctx.send(f"Captain 2 set to {riot_name}#{riot_tag}")
+
+    # Set the bot to development mode
+    @commands.command()
+    @commands.has_role("blood")  
+    async def toggledev(self, ctx):
+        if not self.dev_mode:
+            self.dev_mode = True
+            await ctx.change_presence(activity=discord.Status.do_not_disturb, command_prefix="^")
+        else:
+            self.dev_mode = False
+            await ctx.change_presence(activity=discord.Status.online, command_prefix="!")
 
     # Stop the signup process, only owner can do this
     @commands.command()

--- a/commands.py
+++ b/commands.py
@@ -715,10 +715,12 @@ class BotCommands(commands.Cog):
     async def toggledev(self, ctx):
         if not self.dev_mode:
             self.dev_mode = True
-            await ctx.change_presence(activity=discord.Status.do_not_disturb, command_prefix="^")
+            await self.bot.change_presence(status=discord.Status.do_not_disturb)
+            self.bot.command_prefix="^"
         else:
             self.dev_mode = False
-            await ctx.change_presence(activity=discord.Status.online, command_prefix="!")
+            await self.bot.change_presence(status=discord.Status.online)
+            self.bot.command_prefix="!"
 
     # Stop the signup process, only owner can do this
     @commands.command()

--- a/commands.py
+++ b/commands.py
@@ -199,11 +199,11 @@ class BotCommands(commands.Cog):
                     self.bot.signup_view.cancel_signup_refresh()
 
                     # Pings all users in the active queue (intended for afk mfs)
-                    await interaction.channel.send("__Players:__")
+                    await ctx.send("__Players:__")
                     player_list_msg = ""
                     for player in self.bot.queue:
                         player_list_msg += f"<@{player["id"]}> "
-                    await interaction.channel.send(player_list_msg)
+                    await ctx.send(player_list_msg)
 
                     voting_view = ModeVoteView(ctx, self.bot)
 

--- a/commands.py
+++ b/commands.py
@@ -199,9 +199,11 @@ class BotCommands(commands.Cog):
                     self.bot.signup_view.cancel_signup_refresh()
 
                     # Pings all users in the active queue (intended for afk mfs)
-                    await ctx.send("Players:")
+                    await interaction.channel.send("__Players:__")
+                    player_list_msg = ""
                     for player in self.bot.queue:
-                        await ctx.send(f'<@{player.id}>')
+                        player_list_msg += f"<@{player["id"]}> "
+                    await interaction.channel.send(player_list_msg)
 
                     voting_view = ModeVoteView(ctx, self.bot)
 

--- a/commands.py
+++ b/commands.py
@@ -198,6 +198,11 @@ class BotCommands(commands.Cog):
                     await ctx.send("The queue is now full, proceeding to the voting stage.")
                     self.bot.signup_view.cancel_signup_refresh()
 
+                    # Pings all users in the active queue (intended for afk mfs)
+                    await ctx.send("Players:")
+                    for player in self.bot.queue:
+                        await ctx.send(f'<@{player.id}>')
+
                     voting_view = ModeVoteView(ctx, self.bot)
 
                     # Start vote for how teams will be decided

--- a/commands.py
+++ b/commands.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 import requests
+import random
 
 from database import users, all_matches, mmr_collection
 from views.mode_vote_view import ModeVoteView
@@ -153,10 +154,6 @@ class BotCommands(commands.Cog):
     # Signup Command
     @commands.command()
     async def signup(self, ctx):
-        # Check if we need to create the view
-        if self.bot.signup_view is None:
-            self.bot.signup_view = SignupView(ctx, self.bot)
-
         # Don't create a new signup if one is active
         if self.bot.signup_active:
             await ctx.send("A signup is already in progress. Please wait for it to complete.")
@@ -168,6 +165,16 @@ class BotCommands(commands.Cog):
         self.bot.signup_active = True
 
         self.bot.current_signup_message = await ctx.send("Click a button to manage your queue status!", view=self.bot.signup_view)
+        
+        # Generate Signup Thread
+        self.bot.signup_thread = await self.bot.current_signup_message.create_thread(name=f"10-Man Match #{random.randrange(1, 10**4):04}", auto_archive_duration=60)
+        self.bot.signup_thread_message = await ctx.send(f"Queue Started! Join via the queue thread: <#{self.bot.signup_thread.id}>")
+        await self.bot.signup_thread_message.pin()
+        ctx = self.bot.signup_thread
+
+        # Check if we need to create the view
+        if self.bot.signup_view is None:
+            self.bot.signup_view = SignupView(ctx, self.bot)
 
     # Command to join queue without pressing the button
     @commands.command()
@@ -190,6 +197,8 @@ class BotCommands(commands.Cog):
 
                 # Update the button label
                 await self.bot.signup_view.update_signup()
+
+                await self.bot.signup_thread.add_user(ctx.author)
 
                 await ctx.send(
                     f"{ctx.author.name} added to the queue! Current queue count: {len(self.bot.queue)}")
@@ -233,6 +242,7 @@ class BotCommands(commands.Cog):
                                              player["id"] != ctx.author.id]
             # Update the button label
             await self.bot.signup_view.update_signup()
+            await self.bot.signup_thread.remove_user(ctx.author)
             await ctx.send("You have left the queue.")
 
         else:
@@ -261,6 +271,7 @@ class BotCommands(commands.Cog):
 
         queue_status = ", ".join(riot_names)
         await ctx.send(f"Current queue ({len(self.bot.queue)}/10): {queue_status}")
+        await ctx.send(f"Match Thread: <#{self.bot.signup_thread.id}>")
 
     # Report the match
     @commands.command()
@@ -447,6 +458,12 @@ class BotCommands(commands.Cog):
 
         self.bot.match_not_reported = False
         self.bot.match_ongoing = False
+        try:
+            await self.bot.current_signup_message.delete()
+            await self.bot.signup_thread.delete()
+            await self.bot.signup_thread_message.delete()
+        except discord.NotFound:
+                pass
 
     # Allow players to check their MMR and stats
     @commands.command()
@@ -735,6 +752,8 @@ class BotCommands(commands.Cog):
             self.bot.signup_view.cancel_signup_refresh()
             try:
                 await self.bot.current_signup_message.delete()
+                await self.bot.signup_thread.delete()
+                await self.bot.signup_thread_message.delete()
             except discord.NotFound:
                 pass
             self.bot.current_signup_message = None

--- a/views/captains_drafting_view.py
+++ b/views/captains_drafting_view.py
@@ -263,3 +263,4 @@ class CaptainsDraftingView(discord.ui.View):
             await self.ctx.send(f"{current_captain_name} took too long to pick. Drafting canceled. Count: {self.pick_count}")
 
             self.bot.queue.clear()
+            self.bot.signup_thread.delete()

--- a/views/signup_view.py
+++ b/views/signup_view.py
@@ -43,6 +43,13 @@ class SignupView(discord.ui.View):
                     await interaction.channel.send("The queue is now full, proceeding to the voting stage.")
                     self.cancel_signup_refresh()
 
+                    # Pings all users in the active queue (intended for afk mfs)
+                    await interaction.channel.send("__Players:__")
+                    player_list_msg = ""
+                    for player in self.bot.queue:
+                        player_list_msg += f"<@{player["id"]}> "
+                    await interaction.channel.send(player_list_msg)
+
                     self.bot.signup_active = False
 
                     mode_vote = ModeVoteView(self.ctx, self.bot)

--- a/views/signup_view.py
+++ b/views/signup_view.py
@@ -39,6 +39,8 @@ class SignupView(discord.ui.View):
                     ephemeral=True,
                 )
 
+                await self.bot.signup_thread.add_user(interaction.user)
+
                 if len(self.bot.queue) == 10:
                     await interaction.channel.send("The queue is now full, proceeding to the voting stage.")
                     self.cancel_signup_refresh()
@@ -72,6 +74,8 @@ class SignupView(discord.ui.View):
             ephemeral=True,
         )
 
+        await self.bot.signup_thread.remove_user(interaction.user)
+
     def setup_callbacks(self):
         self.sign_up_button.callback = self.sign_up_callback
         self.leave_queue_button.callback = self.leave_queue_callback
@@ -80,17 +84,14 @@ class SignupView(discord.ui.View):
     async def refresh_signup_message(self):
         try:
             while self.bot.signup_active:
-
-                await asyncio.sleep(60)
-
                 if self.bot.current_signup_message:
                     try:
                         await self.bot.current_signup_message.delete()
                     except discord.NotFound:
                         pass
-
                 # Send new signup message
-                self.bot.current_signup_message = await self.ctx.send("Click a button to manage your queue status!", view=self)
+                self.bot.current_signup_message = await self.bot.signup_thread.send("Click a button to manage your queue status!", view=self, silent=True)
+                await asyncio.sleep(60)
         except asyncio.CancelledError:
             pass
 


### PR DESCRIPTION
!toggledev
- Sets the command prefix to "^" (e.g. ^signup) so regular commands wont work while bot is being worked on
- Sets the bot status to Do not Disturb

(this all resets back to normal by running ^toggledev)