### PR TITLE
moved map pick to before captains draft

### DIFF
--- a/views/captains_drafting_view.py
+++ b/views/captains_drafting_view.py
@@ -10,10 +10,11 @@ from views.map_type_vote_view import MapTypeVoteView
 
 
 class CaptainsDraftingView(discord.ui.View):
-    def __init__(self, ctx, bot):
+    def __init__(self, ctx, bot, map_object):
         super().__init__(timeout=None)
         self.ctx = ctx
         self.bot = bot
+        self.map_object = map_object
 
         self.player_select = Select(
             placeholder="Select a player to pick",
@@ -109,10 +110,8 @@ class CaptainsDraftingView(discord.ui.View):
         # Display final teams
         await self.ctx.send(embed=final_teams_embed)
 
-        map_type_vote = MapTypeVoteView(self.ctx, self.bot)
-
         # Begin vote for competitive or all maps
-        await map_type_vote.send_view()
+        await self.map_object.finalize()
 
     async def select_callback(self, interaction: discord.Interaction):
         current_captain_id = self.pick_order[self.pick_count]["id"]

--- a/views/map_vote_view.py
+++ b/views/map_vote_view.py
@@ -20,6 +20,8 @@ class MapVoteView(discord.ui.View):
         self.map_votes = {}
         self.chosen_maps = []
 
+        self.winning_map = ""
+
         self.voters = set()
 
     async def setup(self):
@@ -68,11 +70,13 @@ class MapVoteView(discord.ui.View):
 
         await asyncio.sleep(25)
 
-        winning_map = max(self.map_votes, key=self.map_votes.get)
-        await self.ctx.send(f"The selected map is **{winning_map}**!")
-        self.bot.selected_map = winning_map
+        self.winning_map = max(self.map_votes, key=self.map_votes.get)
+        await self.ctx.send(f"The selected map is **{self.winning_map}**!")
+    
+    async def finalize(self):
+        self.bot.selected_map = self.winning_map
         teams_embed = discord.Embed(
-            title=f"Teams for the match on {winning_map}",
+            title=f"Teams for the match on {self.winning_map}",
             description="Good luck to both teams!",
             color=discord.Color.blue(),
         )

--- a/views/mode_vote_view.py
+++ b/views/mode_vote_view.py
@@ -10,10 +10,11 @@ from views.map_type_vote_view import MapTypeVoteView
 
 
 class SecondCaptainChoiceView(View):
-    def __init__(self, ctx, bot):
+    def __init__(self, ctx, bot, map_object):
         super().__init__(timeout=None)
         self.ctx = ctx
         self.bot = bot
+        self.map_object = map_object
         self.first_pick_button = Button(label="Single Pick (2nd MMR first)", style=discord.ButtonStyle.green)
         self.double_pick_button = Button(label="Double Pick (2nd and 3rd picks)", style=discord.ButtonStyle.blurple)
 
@@ -42,7 +43,7 @@ class SecondCaptainChoiceView(View):
         await self.start_draft(single_pick=False)
 
     async def start_draft(self, single_pick: bool):
-        drafting_view = CaptainsDraftingView(self.ctx, self.bot)
+        drafting_view = CaptainsDraftingView(self.ctx, self.bot, self.map_object)
         
         # Highest MMR: self.bot.captain1
         # Second highest MMR: self.bot.captain2
@@ -185,8 +186,13 @@ class ModeVoteView(discord.ui.View):
             f"Captain 2: {captain2['name']} (MMR: {self.bot.player_mmr[captain2['id']]['mmr']})"
         )
 
+        map_type_vote = MapTypeVoteView(self.ctx, self.bot)
+
+        # Begin vote for competitive or all maps
+        await map_type_vote.send_view()
+
         # Give second captain choice between first or second and third picks
-        choice_view = SecondCaptainChoiceView(self.ctx, self.bot)
+        choice_view = SecondCaptainChoiceView(self.ctx, self.bot, map_type_vote)
         await self.ctx.send(
             f"{captain2['name']}, please choose the draft type:",
             view=choice_view


### PR DESCRIPTION
Updated mode_vote_view.py, map_vote_view.py, and captains_drafting_view.py to trigger map vote before the captains draft teams (in the event captains mode is chosen). MapVoteView.send_view() has been broken into too functions, one which will decide the winning map, and one which will finalize teams and send the embed later. A map object is now being passed between the effected classes to enable this. **Please review before merging** 