### PR TITLE
Update report.py

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -23,6 +23,9 @@ async def setup(bot):
 class ReportCommand(BotCommands):
     @commands.command()
     async def report(self, ctx):
+        # ADD THIS IMMEDIATE RESPONSE - This is the fix for issue #119
+        await ctx.send("🔄 Processing match report... Please wait while I fetch the match data.")
+        
         # linkage check
         current_user = users.find_one({"discord_id": str(ctx.author.id)})
         if not current_user:


### PR DESCRIPTION
# 🔄 Add immediate response to !report command

## Description
This pull request addresses issue #119 by adding an immediate acknowledgment message to the `!report` command. Previously, users had to wait for the entire match processing and API calls to complete before receiving any feedback, which could take several seconds and leave users uncertain if their command was received.

## Changes Made
- Added immediate response message at the beginning of the `report()` function in `commands/report.py`
- The bot now sends "🔄 Processing match report... Please wait while I fetch the match data." immediately when the command is executed
- All existing functionality remains unchanged

## Problem Solved
**Before**: Users would run `!report` and wait in silence while the bot:
- Validates user linkage
- Fetches match data from HenrikDev API
- Processes team assignments
- Updates MMR and stats
- Saves to database

**After**: Users immediately see confirmation that their command was received and is being processed, providing better user experience and reducing confusion.

## Code Changes
```python
@commands.command()
async def report(self, ctx):
    # ADD THIS IMMEDIATE RESPONSE - This is the fix for issue #119
    await ctx.send("🔄 Processing match report... Please wait while I fetch the match data.")
    
    # Rest of existing code continues unchanged...