### PR TITLE
Patch 1.7.0

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -98,27 +98,22 @@ class CustomBot(commands.Bot):
         current_num = int(current.get("season_number", 0))
         next_num = current_num + 1
 
-        # Update Current Season
-        seasons.update_one(
-            {"_id": "current"},
-            {
-                "$set": {
-                    "_id": current_num,
-                    "matches_played": current.get("matches_played"),
-                    "season_number": current_num,
-                    "winner_mmr": winner.get("mmr"),
-                    "winner_name": winner.get("name"),
-                    "winner_player_id": winner.get("player_id"),
-                    "started_at": current.get("started_at"),
-                    "ended_at": datetime.now(timezone.utc),
-                },
-            },
-            upsert=True,
-        )
+        # Save Old Season
+        old_season_obj = {
+            "_id": current_num,
+            "matches_played": current.get("matches_played"),
+            "season_number": current_num,
+            "winner_mmr": winner.get("mmr"),
+            "winner_name": winner.get("name"),
+            "winner_player_id": winner.get("player_id"),
+            "started_at": current.get("started_at"),
+            "ended_at": datetime.now(timezone.utc),
+        }
+        seasons.insert_one(old_season_obj)
 
         # Create New Season
+
         new_season_obj = {
-            "_id": "current",
             "matches_played": 0,
             "season_number": next_num,
             "winner_mmr": None,
@@ -127,7 +122,12 @@ class CustomBot(commands.Bot):
             "started_at": datetime.now(timezone.utc),
             "ended_at": None,
         }
-        seasons.insert_one(new_season_obj)
+
+        seasons.update_one(
+            {"_id": "current"},
+            {"$set": new_season_obj},
+            upsert=True,
+        )
 
         if reset_player_stats:
             self._reset_all_players_for_new_season(next_num)

--- a/bot.py
+++ b/bot.py
@@ -57,11 +57,14 @@ class CustomBot(commands.Bot):
             {"_id": "current"},
             {
                 "$setOnInsert": {
-                    "season_number": 1,
-                    "started_at": datetime.now(timezone.utc),
+                    "_id": "current",
                     "matches_played": 0,
-                    "is_closed": False,
-                    "reset_period_months": 2,  # 2-month seasons
+                    "season_number": 0,
+                    "winner_mmr": None,
+                    "winner_name": None,
+                    "winner_player_id": None,
+                    "started_at": datetime.now(timezone.utc),
+                    "ended_at": None,
                 }
             },
             upsert=True,
@@ -90,42 +93,46 @@ class CustomBot(commands.Bot):
             tzinfo=timezone.utc,
         )
 
-    def create_new_season(self, *, reset_player_stats: bool = True) -> dict:
-        now_utc = datetime.now(timezone.utc)
-        starts = now_utc
-        ends = self._two_months_after(starts)
+    def create_new_season(self, *, reset_player_stats: bool = True, winner) -> dict:
+        current = seasons.find_one({"_id": "current"})
+        current_num = int(current.get("season_number", 0))
+        next_num = current_num + 1
 
-        current = seasons.find_one({"_id": "current"}) or {}
-        next_num = int(current.get("season_number", 0)) + 1
-
+        # Update Current Season
         seasons.update_one(
             {"_id": "current"},
             {
                 "$set": {
-                    "season_number": next_num,
-                    "started_at": starts,
-                    "is_closed": False,
-                    "reset_period_months": 2,
-                    "matches_played": 0,
-                    "ends_at_expected": ends,
+                    "_id": current_num,
+                    "matches_played": current.get("matches_played"),
+                    "season_number": current_num,
+                    "winner_mmr": winner.get("mmr"),
+                    "winner_name": winner.get("name"),
+                    "winner_player_id": winner.get("player_id"),
+                    "started_at": current.get("started_at"),
+                    "ended_at": datetime.now(timezone.utc),
                 },
-                "$unset": {"ended_at": ""},
             },
             upsert=True,
         )
 
+        # Create New Season
+        new_season_obj = {
+            "_id": "current",
+            "matches_played": 0,
+            "season_number": next_num,
+            "winner_mmr": None,
+            "winner_name": None,
+            "winner_player_id": None,
+            "started_at": datetime.now(timezone.utc),
+            "ended_at": None,
+        }
+        seasons.insert_one(new_season_obj)
+
         if reset_player_stats:
             self._reset_all_players_for_new_season(next_num)
 
-        # Return a small dict used by the newseason command for display
-        return {
-            "season_number": next_num,
-            "started_at": starts,  # UTC
-            "ends_at_expected": ends,  # UTC
-            "started_at_cst": starts.astimezone(TIME_ZONE_CST),
-            "ends_at_cst": ends.astimezone(TIME_ZONE_CST),
-            "is_closed": False,
-        }
+        return new_season_obj
 
     def _reset_all_players_for_new_season(self, season_number: int) -> None:
         """

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -41,15 +41,26 @@ class AdminCommands(BotCommands):
             name=f"Season {doc['season_number'] - 1}", hoist=True
         )
         await ctx.guild.edit_role_positions(positions={ssr_role: 5})
-        await ssr_role.edit(color="#1cd3d8")
-        winner_member = ctx.guild.get_member(winner_doc["player_id"])
+        await ssr_role.edit(color=discord.Color.teal())
+        winner_member = ctx.guild.get_member(int(winner_doc["player_id"]))
         await winner_member.add_roles(ssr_role)
 
-        await ctx.send(
-            f"**Season {doc['season_number']}** started.\n"
+        # Try to send to 'announcements' channel if it exists
+        announcement_channel = None
+        if ctx.guild:
+            for channel in ctx.guild.text_channels:
+                if channel.name.lower() == "announcements":
+                    announcement_channel = channel
+                    break
+        message = (
+            f"**<@1311935865626431529> Season {doc['season_number']}** started.\n"
             f"<@{winner_doc['player_id']}> has been awarded the **Season {doc['season_number'] - 1} SSR** role!\n"
             f"{'All player MMR + stats were reset.' if reset else 'Player stats were preserved (no reset).'}"
         )
+        if announcement_channel:
+            await announcement_channel.send(message)
+        else:
+            await ctx.send(message)
 
     @commands.command()
     @commands.has_role("Owner")

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -81,7 +81,7 @@ class AdminCommands(BotCommands):
             f"Simulated full queue: {', '.join([player['name'] for player in queue])}"
         )
 
-        await ctx.send("The queue is now full, proceeding to the voting stage.")
+        await ctx.send("The queue is now full! Proceeding with match setup...")
 
         mode_vote = ModeVoteView(ctx, self.bot)
         await mode_vote.send_view()

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 
 from commands import BotCommands
+from commands.report import cleanup_match_resources
 from database import mmr_collection
 from views.signup_view import SignupView
 from views.mode_vote_view import ModeVoteView
@@ -112,30 +113,40 @@ class AdminCommands(BotCommands):
             except discord.HTTPException:
                 pass
 
-    # Stop the signup process
+    # Stop the signup process or cancel an active match
     @commands.command()
     @commands.has_role("Owner")
     async def cancel(self, ctx):
-        if not self.bot.signup_active:
-            await ctx.send("No signup is active to cancel")
-            return
+        if self.bot.signup_active:
+            if self.bot.signup_view:
+                self.bot.signup_view.cleanup()
+                self.bot.signup_view = None
 
-        if self.bot.signup_view:
-            self.bot.signup_view.cleanup()
-            self.bot.signup_view = None
+            self.bot.queue = []
+            self.bot.current_signup_message = None
+            self.bot.signup_active = False
 
-        self.bot.queue = []
-        self.bot.current_signup_message = None
-        self.bot.signup_active = False
+            await ctx.send(
+                "Canceled active signup. Feel free to start a new one with `!signup`."
+            )
+            print("Cancelling signup...")
 
-        await ctx.send("Canceled Signup")
-        print("Cancelling signup...")
-
-        try:
-            await self.bot.match_channel.delete()
-            await self.bot.match_role.delete()
-        except discord.NotFound:
-            pass
+            try:
+                await self.bot.match_channel.delete()
+                await self.bot.match_role.delete()
+            except discord.NotFound:
+                pass
+        elif self.bot.match_ongoing and self.bot.selected_map:
+            # Logic to cancel the current match and clear info from memory
+            self.bot.match_not_reported = False
+            self.bot.match_ongoing = False
+            await cleanup_match_resources(self.bot)
+            await ctx.send(
+                "Cancelled active match. Feel free to start a new one with `!signup`."
+            )
+            print("Cancelling active match...")
+        else:
+            await ctx.send("No active signup or match to cancel.")
 
     @commands.command()
     @commands.has_role("Owner")

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -20,7 +20,7 @@ class AdminCommands(BotCommands):
     @commands.has_permissions(administrator=True)
     async def new_season(self, ctx, *, no_reset: str = None):
         """
-        Creates a new season that ends exactly 2 calendar months from now (UTC).
+        Creates a new season, saving seasons stats, and assigning SSR rank.
         By default, resets everyone’s MMR + stats. If you pass 'noreset', it will keep stats.
         Usage: !newseason    (resets)
             !newseason noreset
@@ -29,18 +29,25 @@ class AdminCommands(BotCommands):
         if no_reset and no_reset.lower() in {"noreset", "keep", "false", "0"}:
             reset = False
 
-        doc = self.bot.create_new_season(reset_player_stats=reset)
+        # Determine winner info
+        winner_doc = mmr_collection.find_one(
+            {"matches_played": {"$gt": 0}}, sort=[("mmr", -1)]
+        )
 
-        start_cst = doc["started_at_cst"]
-        end_cst = doc["ends_at_cst"]
+        doc = self.bot.create_new_season(reset_player_stats=reset, winner=winner_doc)
 
-        start_str = start_cst.strftime("%Y-%m-%d %I:%M %p %Z")
-        end_str = end_cst.strftime("%Y-%m-%d %I:%M %p %Z")
+        # Assign SSR Rank to winner
+        ssr_role = await ctx.guild.create_role(
+            name=f"Season {doc['season_number'] - 1}", hoist=True
+        )
+        await ctx.guild.edit_role_positions(positions={ssr_role: 5})
+        await ssr_role.edit(color="#1cd3d8")
+        winner_member = ctx.guild.get_member(winner_doc["player_id"])
+        await winner_member.add_roles(ssr_role)
 
         await ctx.send(
-            f"**Season {doc['season_number']}** created.\n"
-            f"Starts (Central): `{start_str}`\n"
-            f"Ends (Central):   `{end_str}`\n"
+            f"**Season {doc['season_number']}** started.\n"
+            f"<@{winner_doc['player_id']}> has been awarded the **Season {doc['season_number'] - 1} SSR** role!\n"
             f"{'All player MMR + stats were reset.' if reset else 'Player stats were preserved (no reset).'}"
         )
 

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -38,7 +38,7 @@ class AdminCommands(BotCommands):
 
         # Assign SSR Rank to winner
         ssr_role = await ctx.guild.create_role(
-            name=f"Season {doc['season_number'] - 1}", hoist=True
+            name=f"Season {doc['season_number'] - 1} SSR", hoist=True
         )
         await ctx.guild.edit_role_positions(positions={ssr_role: 5})
         await ssr_role.edit(color=discord.Color.teal())

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -53,7 +53,7 @@ class AdminCommands(BotCommands):
                     announcement_channel = channel
                     break
         message = (
-            f"**<@1311935865626431529> Season {doc['season_number']}** started.\n"
+            f"**<@&1311935865626431529> Season {doc['season_number']}** started.\n"
             f"<@{winner_doc['player_id']}> has been awarded the **Season {doc['season_number'] - 1} SSR** role!\n"
             f"{'All player MMR + stats were reset.' if reset else 'Player stats were preserved (no reset).'}"
         )

--- a/commands/report.py
+++ b/commands/report.py
@@ -113,6 +113,8 @@ async def cleanup_match_resources(bot):
 class ReportCommand(BotCommands):
     @commands.command()
     async def report(self, ctx):
+        await ctx.send("Attempting to report latest match...")
+
         # linkage check
         current_user = users.find_one({"discord_id": str(ctx.author.id)})
         if not current_user:

--- a/commands/report.py
+++ b/commands/report.py
@@ -595,6 +595,11 @@ class ReportCommand(BotCommands):
         self.bot.match_ongoing = False
         await cleanup_match_resources(self.bot)
 
+        # Increment Current Season Match Count
+        seasons.update_one(
+            {"_id": "current"}, {"$inc": {"matches_played": 1}}, upsert=True
+        )
+
 
 def rounds_to_int(value):
     if isinstance(value, dict):

--- a/commands/report.py
+++ b/commands/report.py
@@ -20,6 +20,96 @@ async def setup(bot):
     await bot.add_cog(ReportCommand(bot))
 
 
+async def cleanup_match_resources(bot):
+    await bot.wait_until_ready()
+    try:
+        if hasattr(bot, "match_channel") and bot.match_channel:
+            try:
+                await bot.match_channel.delete()
+            except discord.NotFound:
+                print("[DEBUG] Match channel already deleted")
+            except discord.Forbidden:
+                print("[DEBUG] Missing permissions to delete match channel")
+            finally:
+                bot.match_channel = None
+
+        if hasattr(bot, "match_role") and bot.match_role:
+
+            try:
+                for member in bot.match_role.members:
+                    await member.remove_roles(bot.match_role)
+            except discord.HTTPException:
+                print("[DEBUG] Error removing roles from members")
+
+            # delete the role
+            try:
+                await bot.match_role.delete()
+            except discord.NotFound:
+                print("[DEBUG] Match role already deleted")
+            except discord.Forbidden:
+                print("[DEBUG] Missing permissions to delete match role")
+            finally:
+                bot.match_role = None
+
+        bot.match_not_reported = False
+        bot.match_ongoing = False
+        bot.queue.clear()
+
+        if bot.current_signup_message:
+            try:
+                await bot.current_signup_message.delete()
+            except discord.NotFound:
+                pass
+            finally:
+                bot.current_signup_message = None
+
+    except Exception as e:
+        print(f"[DEBUG] Error during cleanup: {str(e)}")
+        try:
+            if hasattr(bot, "match_channel") and bot.match_channel:
+                try:
+                    await bot.match_channel.delete()
+                except discord.NotFound:
+                    print("[DEBUG] Match channel already deleted")
+                except discord.Forbidden:
+                    print("[DEBUG] Missing permissions to delete match channel")
+                finally:
+                    bot.match_channel = None
+
+            if hasattr(bot, "match_role") and bot.match_role:
+
+                try:
+                    for member in bot.match_role.members:
+                        await member.remove_roles(bot.match_role)
+                except discord.HTTPException:
+                    print("[DEBUG] Error removing roles from members")
+
+                # delete the role
+                try:
+                    await bot.match_role.delete()
+                except discord.NotFound:
+                    print("[DEBUG] Match role already deleted")
+                except discord.Forbidden:
+                    print("[DEBUG] Missing permissions to delete match role")
+                finally:
+                    bot.match_role = None
+
+            bot.match_not_reported = False
+            bot.match_ongoing = False
+            bot.queue.clear()
+
+            if bot.current_signup_message:
+                try:
+                    await bot.current_signup_message.delete()
+                except discord.NotFound:
+                    pass
+                finally:
+                    bot.current_signup_message = None
+
+        except Exception as e:
+            print(f"[DEBUG] Error during cleanup: {str(e)}")
+
+
 class ReportCommand(BotCommands):
     @commands.command()
     async def report(self, ctx):
@@ -501,96 +591,7 @@ class ReportCommand(BotCommands):
         await asyncio.sleep(5)
         self.bot.match_not_reported = False
         self.bot.match_ongoing = False
-        await self.cleanup_match_resources()
-
-    async def cleanup_match_resources(self):
-        await self.bot.wait_until_ready()
-        try:
-            if hasattr(self.bot, "match_channel") and self.bot.match_channel:
-                try:
-                    await self.bot.match_channel.delete()
-                except discord.NotFound:
-                    print("[DEBUG] Match channel already deleted")
-                except discord.Forbidden:
-                    print("[DEBUG] Missing permissions to delete match channel")
-                finally:
-                    self.bot.match_channel = None
-
-            if hasattr(self.bot, "match_role") and self.bot.match_role:
-
-                try:
-                    for member in self.bot.match_role.members:
-                        await member.remove_roles(self.bot.match_role)
-                except discord.HTTPException:
-                    print("[DEBUG] Error removing roles from members")
-
-                # delete the role
-                try:
-                    await self.bot.match_role.delete()
-                except discord.NotFound:
-                    print("[DEBUG] Match role already deleted")
-                except discord.Forbidden:
-                    print("[DEBUG] Missing permissions to delete match role")
-                finally:
-                    self.bot.match_role = None
-
-            self.bot.match_not_reported = False
-            self.bot.match_ongoing = False
-            self.bot.queue.clear()
-
-            if self.bot.current_signup_message:
-                try:
-                    await self.bot.current_signup_message.delete()
-                except discord.NotFound:
-                    pass
-                finally:
-                    self.bot.current_signup_message = None
-
-        except Exception as e:
-            print(f"[DEBUG] Error during cleanup: {str(e)}")
-            try:
-                if hasattr(self.bot, "match_channel") and self.bot.match_channel:
-                    try:
-                        await self.bot.match_channel.delete()
-                    except discord.NotFound:
-                        print("[DEBUG] Match channel already deleted")
-                    except discord.Forbidden:
-                        print("[DEBUG] Missing permissions to delete match channel")
-                    finally:
-                        self.bot.match_channel = None
-
-                if hasattr(self.bot, "match_role") and self.bot.match_role:
-
-                    try:
-                        for member in self.bot.match_role.members:
-                            await member.remove_roles(self.bot.match_role)
-                    except discord.HTTPException:
-                        print("[DEBUG] Error removing roles from members")
-
-                    # delete the role
-                    try:
-                        await self.bot.match_role.delete()
-                    except discord.NotFound:
-                        print("[DEBUG] Match role already deleted")
-                    except discord.Forbidden:
-                        print("[DEBUG] Missing permissions to delete match role")
-                    finally:
-                        self.bot.match_role = None
-
-                self.bot.match_not_reported = False
-                self.bot.match_ongoing = False
-                self.bot.queue.clear()
-
-                if self.bot.current_signup_message:
-                    try:
-                        await self.bot.current_signup_message.delete()
-                    except discord.NotFound:
-                        pass
-                    finally:
-                        self.bot.current_signup_message = None
-
-            except Exception as e:
-                print(f"[DEBUG] Error during cleanup: {str(e)}")
+        await cleanup_match_resources(self.bot)
 
 
 def rounds_to_int(value):

--- a/commands/report.py
+++ b/commands/report.py
@@ -569,36 +569,15 @@ class ReportCommand(BotCommands):
         # Record every match played in a new collection
         all_matches.insert_one(match)
 
-        now_utc = datetime.now(timezone.utc)
-        current = seasons.find_one({"_id": "current"}) or {}
-
-        started_at = convert_to_utc(current.get("started_at"))  # <-- normalize
-        reset_months = int(current.get("reset_period_months", 2))
-
-        if not started_at:
-            started_at = now_utc
-            seasons.update_one(
-                {"_id": "current"},
-                {"$set": {"started_at": started_at, "is_closed": False}},
-                upsert=True,
-            )
-
-        season_end_utc = convert_to_utc(
-            _add_months(started_at, reset_months)
-        )  # <-- normalize
-
-        if not current.get("is_closed", False) and now_utc >= season_end_utc:
-            await end_season(ctx, started_at_utc=started_at, ended_at_utc=now_utc)
+        # Increment Current Season Match Count
+        seasons.update_one(
+            {"_id": "current"}, {"$inc": {"matches_played": 1}}, upsert=True
+        )
 
         await asyncio.sleep(5)
         self.bot.match_not_reported = False
         self.bot.match_ongoing = False
         await cleanup_match_resources(self.bot)
-
-        # Increment Current Season Match Count
-        seasons.update_one(
-            {"_id": "current"}, {"$inc": {"matches_played": 1}}, upsert=True
-        )
 
 
 def rounds_to_int(value):
@@ -627,86 +606,3 @@ def rounds_to_int(value):
         return int(value)
     except Exception:
         return 0
-
-
-async def end_season(ctx, started_at_utc=None, ended_at_utc=None):
-    current = seasons.find_one({"_id": "current"}) or {}
-    if current.get("is_closed"):
-        return
-
-    now_utc = datetime.now(timezone.utc)
-
-    started_at_utc = convert_to_utc(
-        started_at_utc or current.get("started_at") or now_utc
-    )
-    ended_at_utc = convert_to_utc(ended_at_utc or now_utc)
-
-    # Determine winner
-    top_doc = mmr_collection.find_one(sort=[("mmr", -1)])
-    if not top_doc:
-        winner_player_id = None
-        winner_name = "No players"
-        winner_mmr = 0
-    else:
-        winner_player_id = str(top_doc.get("player_id"))
-        winner_mmr = top_doc.get("mmr", 0)
-
-        u = users.find_one({"discord_id": winner_player_id})
-        if u:
-            winner_name = f"{u.get('name', 'Unknown')}#{u.get('tag', 'Unknown')}"
-        else:
-            winner_name = top_doc.get("name", "Unknown")
-
-    started_cst = started_at_utc.astimezone(TIME_ZONE_CST) if started_at_utc else None
-    ended_cst = ended_at_utc.astimezone(TIME_ZONE_CST)
-    started_str = (
-        started_cst.strftime("%Y-%m-%d %I:%M %p %Z") if started_cst else "unknown"
-    )
-    ended_str = ended_cst.strftime("%Y-%m-%d %I:%M %p %Z")
-
-    await ctx.send(
-        "🏁 **Season complete!**\n"
-        f"**Winner:** {winner_name}\n"
-        f"**Final MMR:** {winner_mmr}\n"
-        f"**Season window (Central):** {started_str} → {ended_str}"
-    )
-
-    seasons.update_one(
-        {"_id": "current"},
-        {
-            "$set": {
-                "is_closed": True,
-                "ended_at": ended_at_utc,
-                "winner_player_id": winner_player_id,
-                "winner_name": winner_name,
-                "winner_mmr": winner_mmr,
-            }
-        },
-        upsert=True,
-    )
-
-    # next season
-    next_season_number = int(current.get("season_number", 1)) + 1
-    reset_period_months = int(current.get("reset_period_months", 2))
-
-    seasons.update_one(
-        {"_id": "current"},
-        {
-            "$set": {
-                "season_number": next_season_number,
-                "started_at": ended_at_utc,
-                "is_closed": False,
-                "reset_period_months": reset_period_months,
-                "matches_played": 0,
-                "last_season": {
-                    "season_number": current.get("season_number", 1),
-                    "started_at": started_at_utc,
-                    "ended_at": ended_at_utc,
-                    "winner_player_id": winner_player_id,
-                    "winner_name": winner_name,
-                    "winner_mmr": winner_mmr,
-                    "matches_played": current.get("matches_played", 0),
-                },
-            }
-        },
-    )

--- a/maps_service.py
+++ b/maps_service.py
@@ -15,110 +15,141 @@ URL = "https://valorant.fandom.com/wiki/Maps"
 
 
 def get_standard_maps() -> list[str]:
-    print("Fetching all standard maps...")
-    response = requests.get(URL, timeout=10)
-    soup = BeautifulSoup(response.text, "html.parser")
+    potentially_outdated_standard_map_list: list = [
+        "Abyss",
+        "Ascent",
+        "Bind",
+        "Breeze",
+        "Corrode",
+        "Fracture",
+        "Haven",
+        "Icebox",
+        "Lotus",
+        "Pearl",
+        "Split",
+        "Sunset",
+    ]
 
-    # Find the table with the "Standard" header
-    standard_header = soup.find("h3", id="Standard")
-    if not standard_header:
-        # Fallback: find by text
-        for h3 in soup.find_all("h3"):
-            if "Standard" in h3.get_text():
-                standard_header = h3
-                break
-    if not standard_header:
-        print(
-            "Warning: Standard maps table not found. Using a potentially outdated map list."
-        )
-        # Fall back to a hard-coded list that may be outdated
-        return [
-            "Abyss",
-            "Ascent",
-            "Bind",
-            "Breeze",
-            "Corrode",
-            "Fracture",
-            "Haven",
-            "Icebox",
-            "Lotus",
-            "Pearl",
-            "Split",
-            "Sunset",
-        ]
-    # The table is after the header
-    table = standard_header.find_next("table")
-    maps = []
-    for row in table.find_all("tr")[1:]:  # skip header row
-        first_td = row.find("td")
-        if first_td:
-            # Find all <a> tags in the first <td>
-            a_tags = first_td.find_all("a", title=True)
-            if a_tags:
-                # The last <a> is the one with the map name
-                map_name = a_tags[-1].get_text(strip=True)
-                if map_name:
-                    maps.append(map_name)
-    print("Standard maps found:")
-    print(maps)
-    return maps
+    print("Fetching all standard maps...")
+    try:
+        response = requests.get(URL, timeout=10)
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Find the table with the "Standard" header
+        standard_header = soup.find("h3", id="Standard")
+        if not standard_header:
+            # Fallback: find by text
+            for h3 in soup.find_all("h3"):
+                if "Standard" in h3.get_text():
+                    standard_header = h3
+                    break
+        if not standard_header:
+            print(
+                "Warning: Standard maps table not found. Using a potentially outdated map list."
+            )
+            return potentially_outdated_standard_map_list
+        # The table is after the header
+        table = standard_header.find_next("table")
+        maps = []
+        for row in table.find_all("tr")[1:]:  # skip header row
+            first_td = row.find("td")
+            if first_td:
+                # Find all <a> tags in the first <td>
+                a_tags = first_td.find_all("a", title=True)
+                if a_tags:
+                    # The last <a> is the one with the map name
+                    map_name = a_tags[-1].get_text(strip=True)
+                    if map_name:
+                        maps.append(map_name)
+        print("Standard maps found:")
+        print(maps)
+        return maps
+    except requests.RequestException:
+        print("Warning: Requests network error. Using a potentially outdated map list.")
+        return potentially_outdated_standard_map_list
 
 
 def get_competitive_maps() -> list[str]:
+    potentially_outdated_competitive_map_list: list = [
+        "Abyss",
+        "Ascent",
+        "Bind",
+        "Corrode",
+        "Haven",
+        "Lotus",
+        "Sunset",
+    ]
+
     print("Fetching standard competitive maps...")
-    response = requests.get(URL, timeout=10)
-    soup = BeautifulSoup(response.text, "html.parser")
+    try:
+        response = requests.get(URL, timeout=10)
+        soup = BeautifulSoup(response.text, "html.parser")
 
-    # Look for any <th> containing 'Current rotation'
-    for th in soup.find_all("th"):
-        if (
-            th.get_text(strip=True).lower().startswith("current rotation")
-            or "current rotation" in th.get_text(strip=True).lower()
-        ):
-            table = th.find_parent("table")
-            break
+        # Look for any <th> containing 'Current rotation'
+        for th in soup.find_all("th"):
+            if (
+                th.get_text(strip=True).lower().startswith("current rotation")
+                or "current rotation" in th.get_text(strip=True).lower()
+            ):
+                table = th.find_parent("table")
+                break
 
-    if table:
-        divs = table.find_all("div", class_="gallery-image-wrapper")
-        ids = [div.get("id") for div in divs if div.get("id")]
-        print("Competitive maps found:")
-        print(ids)
-        return ids
-    else:
-        print(
-            "Warning: Current rotation table not found. Useing a potentially outdated map list."
-        )
-        return ["Abyss", "Ascent", "Bind", "Corrode", "Haven", "Lotus", "Sunset"]
+        if table:
+            divs = table.find_all("div", class_="gallery-image-wrapper")
+            ids = [div.get("id") for div in divs if div.get("id")]
+            print("Competitive maps found:")
+            print(ids)
+            return ids
+        else:
+            print(
+                "Warning: Current rotation table not found. Useing a potentially outdated map list."
+            )
+            return potentially_outdated_competitive_map_list
+    except requests.RequestException:
+        print("Warning: Requests network error. Using a potentially outdated map list.")
+        return potentially_outdated_competitive_map_list
 
 
 def get_tdm_maps() -> list[str]:
-    print("Fetching all Team Deathmatch maps...")
-    response = requests.get(URL, timeout=10)
-    soup = BeautifulSoup(response.text, "html.parser")
+    potentially_outdated_tdm_map_list: list = [
+        "District",
+        "Kasbah",
+        "Piazza",
+        "Drift",
+        "Glitch",
+    ]
 
-    # Find the "Team Deathmatch" header
-    tdm_header = soup.find("h3", id="Team Deathmatch")
-    if not tdm_header:
-        # Fallback: find by text
-        for h3 in soup.find_all("h3"):
-            if "Team Deathmatch" in h3.get_text():
-                tdm_header = h3
-                break
-    if not tdm_header:
-        print("Team Deathmatch maps table not found.")
-        return []
-    # The table is after the header
-    table = tdm_header.find_next("table")
-    maps = []
-    for row in table.find_all("tr")[1:]:  # skip header row
-        first_td = row.find("td")
-        if first_td:
-            # The map name is the text after the <br> tag
-            br = first_td.find("br")
-            if br and br.next_sibling:
-                map_name = br.next_sibling.strip()
-                if map_name:
-                    maps.append(map_name)
-    print("Team Deathmatch maps found:")
-    print(maps)
-    return maps
+    print("Fetching all Team Deathmatch maps...")
+    try:
+        response = requests.get(URL, timeout=10)
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Find the "Team Deathmatch" header
+        tdm_header = soup.find("h3", id="Team Deathmatch")
+        if not tdm_header:
+            # Fallback: find by text
+            for h3 in soup.find_all("h3"):
+                if "Team Deathmatch" in h3.get_text():
+                    tdm_header = h3
+                    break
+        if not tdm_header:
+            print("Team Deathmatch maps table not found.")
+            return potentially_outdated_tdm_map_list
+        # The table is after the header
+        table = tdm_header.find_next("table")
+        maps = []
+        for row in table.find_all("tr")[1:]:  # skip header row
+            first_td = row.find("td")
+            if first_td:
+                # The map name is the text after the <br> tag
+                br = first_td.find("br")
+                if br and br.next_sibling:
+                    map_name = br.next_sibling.strip()
+                    if map_name:
+                        maps.append(map_name)
+        print("Team Deathmatch maps found:")
+        print(maps)
+        return maps
+    except requests.RequestException:
+        print("Warning: Requests network error. Using a potentially outdated map list.")
+        return potentially_outdated_tdm_map_list

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.12.15
+aiohttp==3.13.3
 aiosignal==1.4.0
 attrs==25.3.0
 beautifulsoup4==4.13.5
@@ -20,6 +20,6 @@ soupsieve==2.7
 table2ascii==1.1.3
 typing_extensions==4.14.1
 tzdata==2025.2
-urllib3==2.5.0
+urllib3==2.6.3
 wcwidth==0.2.13
 yarl==1.20.1

--- a/views/captains_drafting_view.py
+++ b/views/captains_drafting_view.py
@@ -149,6 +149,9 @@ class CaptainsDraftingView(discord.ui.View):
         self.pick_count = 0
         self.draft_finished = False
 
+        self.draft_time_remaining = 120
+        self.draft_timer_task = None
+
         self.remaining_players_message = None
         self.drafting_message = None
         self.captain_pick_message = None
@@ -213,6 +216,10 @@ class CaptainsDraftingView(discord.ui.View):
         if self.draft_finished:
             return
         self.draft_finished = True
+
+        if self.draft_timer_task:
+            self.draft_timer_task.cancel()
+            self.draft_timer_task = None
 
         try:
             self.player_select.disabled = True
@@ -340,6 +347,11 @@ class CaptainsDraftingView(discord.ui.View):
         except ValueError:
             pass
 
+        self.draft_time_remaining = 120
+        if self.draft_timer_task:
+            self.draft_timer_task.cancel()
+            self.draft_timer_task = None
+
         if not interaction.response.is_done():
             await interaction.response.defer(ephemeral=True)
 
@@ -350,6 +362,37 @@ class CaptainsDraftingView(discord.ui.View):
             await self.finalize_draft()
             return
         await self.send_current_draft_view()
+
+    def start_draft_timer(self):
+        if self.draft_timer_task:
+            self.draft_timer_task.cancel()
+        self.draft_timer_task = asyncio.create_task(self.draft_timeout_timer())
+
+    async def draft_timeout_timer(self):
+        for _ in range(120):
+            await asyncio.sleep(1)
+            if self.draft_finished:
+                return
+            self.draft_time_remaining -= 1
+            if self.captain_pick_message:
+                current_captain_id = self.pick_order[self.pick_count]["id"]
+                ud = users.find_one({"discord_id": str(current_captain_id)})
+                if ud:
+                    curr_captain_name = (
+                        f"{ud.get('name','Unknown')}#{ud.get('tag','Unknown')}"
+                    )
+                else:
+                    c = (
+                        self.bot.captain1
+                        if self.bot.captain1["id"] == current_captain_id
+                        else self.bot.captain2
+                    )
+                    curr_captain_name = c["name"]
+                message = f"**{curr_captain_name}**, pick a player: ({self.draft_time_remaining}s)"
+                try:
+                    await self.captain_pick_message.edit(content=message, view=self)
+                except discord.NotFound:
+                    pass
 
     async def send_current_draft_view(self):
         if self.draft_finished:
@@ -443,7 +486,9 @@ class CaptainsDraftingView(discord.ui.View):
             )
             curr_captain_name = c["name"]
 
-        message = f"**{curr_captain_name}**, pick a player:"
+        message = (
+            f"**{curr_captain_name}**, pick a player: ({self.draft_time_remaining}s)"
+        )
 
         if (
             self.captain_pick_message
@@ -468,6 +513,8 @@ class CaptainsDraftingView(discord.ui.View):
             )
             self.drafting_message = await self.ctx.send(embed=drafting_embed)
             self.captain_pick_message = await self.ctx.send(content=message, view=self)
+
+        self.start_draft_timer()
 
         if not self.draft_finished:
             # If only one player left, auto-assign and finalize
@@ -527,3 +574,7 @@ class CaptainsDraftingView(discord.ui.View):
                         self.stop()
                     except Exception:
                         pass
+
+                    if self.draft_timer_task:
+                        self.draft_timer_task.cancel()
+                        self.draft_timer_task = None

--- a/views/captains_drafting_view.py
+++ b/views/captains_drafting_view.py
@@ -112,6 +112,27 @@ class SecondCaptainChoiceView(discord.ui.View):
         self.bot.chosen_mode = None
         self.bot.selected_map = None
 
+        try:
+            if getattr(self.bot, "match_channel", None):
+                await self.bot.match_channel.delete()
+        except discord.NotFound:
+            pass
+        finally:
+            self.bot.match_channel = None
+
+        try:
+            if getattr(self.bot, "match_role", None):
+                await self.bot.match_role.delete()
+        except discord.NotFound:
+            pass
+        finally:
+            self.bot.match_role = None
+
+        try:
+            self.stop()
+        except Exception:
+            pass
+
     def cancel_timeout_timer(self):
         if self.timeout_timer_task:
             self.timeout_timer_task.cancel()

--- a/views/captains_drafting_view.py
+++ b/views/captains_drafting_view.py
@@ -13,6 +13,9 @@ class SecondCaptainChoiceView(discord.ui.View):
         super().__init__(timeout=None)
         self.ctx = ctx
         self.bot = bot
+        self.view_message = None
+        self.decision_time_remaining = 120
+        self.timeout_timer_task = asyncio.create_task(self.timeout_timer())
 
         # Buttons
         self.first_pick_button = discord.ui.Button(
@@ -33,35 +36,13 @@ class SecondCaptainChoiceView(discord.ui.View):
         self.add_item(self.double_pick_button)
 
     async def send_view(self):
-        """Show captains and present draft mode choice."""
-        c1_data = users.find_one({"discord_id": str(self.bot.captain1["id"])})
-        c2_data = users.find_one({"discord_id": str(self.bot.captain2["id"])})
-
-        c1_name = (
-            f"{c1_data.get('name', 'Unknown')}#{c1_data.get('tag', 'Unknown')}"
-            if c1_data
-            else self.bot.captain1["name"]
+        await self.ctx.send(
+            f"Captains Chosen: <@{self.bot.captain1['id']}> and <@{self.bot.captain2['id']}>"
         )
-        c2_name = (
-            f"{c2_data.get('name', 'Unknown')}#{c2_data.get('tag', 'Unknown')}"
-            if c2_data
-            else self.bot.captain2["name"]
+        self.view_message = await self.ctx.send(
+            f"<@{self.bot.captain2['id']}>, choose draft type: ({self.decision_time_remaining}s)",
+            view=self,
         )
-
-        embed = discord.Embed(
-            title="Team Captains",
-            description="Choose draft type",
-            color=discord.Color.blue(),
-        )
-        embed.add_field(name="Captain 1", value=c1_name, inline=True)
-        embed.add_field(name="Captain 2", value=c2_name, inline=True)
-        embed.add_field(
-            name="Instructions",
-            value=f"<@{self.bot.captain2['id']}> must choose either Single Pick or Double Pick",
-            inline=False,
-        )
-
-        await self.ctx.send(embed=embed, view=self)
 
     async def _validate_second_captain(self, interaction: discord.Interaction) -> bool:
         if str(interaction.user.id) != str(self.bot.captain2["id"]):
@@ -75,7 +56,7 @@ class SecondCaptainChoiceView(discord.ui.View):
         if not await self._validate_second_captain(interaction):
             return
 
-        # Disable buttons after
+        self.cancel_timeout_timer()
         self.first_pick_button.disabled = True
         self.double_pick_button.disabled = True
         await interaction.message.edit(view=self)
@@ -87,6 +68,7 @@ class SecondCaptainChoiceView(discord.ui.View):
         if not await self._validate_second_captain(interaction):
             return
 
+        self.cancel_timeout_timer()
         self.first_pick_button.disabled = True
         self.double_pick_button.disabled = True
         await interaction.message.edit(view=self)
@@ -107,6 +89,33 @@ class SecondCaptainChoiceView(discord.ui.View):
         # Lock buttons
         for child in self.children:
             child.disabled = True
+
+    async def timeout_timer(self):
+        for _ in range(120):
+            await asyncio.sleep(1)
+            self.decision_time_remaining -= 1
+            if self.view_message:
+                self.view_message = await self.ctx.send(
+                    f"<@{self.bot.captain2['id']}>, choose draft type: ({self.decision_time_remaining}s)",
+                    view=self,
+                )
+        # Cancel Signup
+        await self.ctx.send("The captain took too long. Match will be cancelled...")
+        self.bot.signup_active = False
+        self.bot.match_ongoing = False
+        self.bot.match_not_reported = False
+        self.bot.queue.clear()
+        self.bot.team1 = []
+        self.bot.team2 = []
+        self.bot.captain1 = None
+        self.bot.captain2 = None
+        self.bot.chosen_mode = None
+        self.bot.selected_map = None
+
+    def cancel_timeout_timer(self):
+        if self.timeout_timer_task:
+            self.timeout_timer_task.cancel()
+            self.timeout_timer_task = None
 
 
 class CaptainsDraftingView(discord.ui.View):
@@ -538,7 +547,7 @@ class CaptainsDraftingView(discord.ui.View):
             except asyncio.TimeoutError:
                 if not self.draft_finished:
                     await self.ctx.send(
-                        f"{curr_captain_name} took too long. Draft canceled. Cleaning up…"
+                        f"{curr_captain_name} took too long. Match will be cancelled..."
                     )
                     await asyncio.sleep(2)
 

--- a/views/captains_drafting_view.py
+++ b/views/captains_drafting_view.py
@@ -95,8 +95,8 @@ class SecondCaptainChoiceView(discord.ui.View):
             await asyncio.sleep(1)
             self.decision_time_remaining -= 1
             if self.view_message:
-                self.view_message = await self.ctx.send(
-                    f"<@{self.bot.captain2['id']}>, choose draft type: ({self.decision_time_remaining}s)",
+                await self.view_message.edit(
+                    content=f"<@{self.bot.captain2['id']}>, choose draft type: ({self.decision_time_remaining}s)",
                     view=self,
                 )
         # Cancel Signup

--- a/views/map_type_vote_view.py
+++ b/views/map_type_vote_view.py
@@ -46,11 +46,14 @@ class MapTypeVoteView(discord.ui.View):
         self.timeout = False
         self.view_message = None
         self.vote_lock = asyncio.Lock()
+        self.vote_time_remaining = 25
 
         print("Starting new map type vote...")
 
     async def send_view(self):
-        self.view_message = await self.ctx.send("Vote for the map pool:", view=self)
+        self.view_message = await self.ctx.send(
+            f"Vote for the map pool: ({self.vote_time_remaining}s)", view=self
+        )
 
     async def vote_callback(self, interaction: discord.Interaction, mode: str):
         # Defer the interaction if not already done, to allow time for processing
@@ -166,7 +169,7 @@ class MapTypeVoteView(discord.ui.View):
         for child in self.children:
             if isinstance(child, discord.ui.Button):
                 child.disabled = True
-        await self.view_message.edit(view=self)
+        await self.view_message.edit(content="Vote for the map pool:", view=self)
 
         if chosen_map_type == "Competitive":
             map_list: list[str] = get_competitive_maps()
@@ -181,7 +184,16 @@ class MapTypeVoteView(discord.ui.View):
         self.cancel_timeout_timer()
 
     async def timeout_timer(self):
-        await asyncio.sleep(25)
+        for _ in range(25):
+            await asyncio.sleep(1)
+            if self.voting_phase_ended:
+                return
+            self.vote_time_remaining -= 1
+            if self.view_message:
+                await self.view_message.edit(
+                    content=f"Vote for the map pool: ({self.vote_time_remaining}s)",
+                    view=self,
+                )
         if not self.voting_phase_ended:
             self.timeout = True
             await self.check_for_winner()

--- a/views/map_vote_view.py
+++ b/views/map_vote_view.py
@@ -34,6 +34,7 @@ class MapVoteView(discord.ui.View):
         self.view_message = None
         self.voting_phase_ended = False
         self.vote_lock = asyncio.Lock()
+        self.vote_time_remaining = 25
 
         print("Starting new map vote...")
 
@@ -73,7 +74,9 @@ class MapVoteView(discord.ui.View):
         for button in self.map_buttons:
             self.add_item(button)
 
-        self.view_message = await self.ctx.send("Vote for the map to play:", view=self)
+        self.view_message = await self.ctx.send(
+            f"Vote for the map to play: ({self.vote_time_remaining}s)", view=self
+        )
 
     async def process_interaction_queue(self):
         while True:
@@ -170,7 +173,7 @@ class MapVoteView(discord.ui.View):
         for child in self.children:
             if isinstance(child, discord.ui.Button):
                 child.disabled = True
-        await self.view_message.edit(view=self)
+        await self.view_message.edit(content="Vote for the map to play:", view=self)
 
         # Finalize match setup
         if self.bot.chosen_mode == "Balanced":
@@ -186,7 +189,9 @@ class MapVoteView(discord.ui.View):
                     self.cancel_interaction_queue_task()
                     self.cancel_timeout_timer()
                     return
-
+            await self.ctx.send(
+                f"Captains Chosen: <@{self.bot.captain1['id']}> and <@{self.bot.captain2['id']}>"
+            )
             choice_view = SecondCaptainChoiceView(self.ctx, self.bot)
             await self.ctx.send(
                 f"<@{self.bot.captain2['id']}>, choose draft type:", view=choice_view
@@ -282,7 +287,16 @@ class MapVoteView(discord.ui.View):
         await self.bot.match_channel.edit(name=f"{self.bot.match_name}《in-game》")
 
     async def timeout_timer(self):
-        await asyncio.sleep(25)
+        for _ in range(25):
+            await asyncio.sleep(1)
+            if self.voting_phase_ended:
+                return
+            self.vote_time_remaining -= 1
+            if self.view_message:
+                await self.view_message.edit(
+                    content=f"Vote for the map to play ({self.vote_time_remaining}s):",
+                    view=self,
+                )
         if not self.voting_phase_ended:
             self.timeout = True
             await self.check_for_winner()

--- a/views/map_vote_view.py
+++ b/views/map_vote_view.py
@@ -189,13 +189,9 @@ class MapVoteView(discord.ui.View):
                     self.cancel_interaction_queue_task()
                     self.cancel_timeout_timer()
                     return
-            await self.ctx.send(
-                f"Captains Chosen: <@{self.bot.captain1['id']}> and <@{self.bot.captain2['id']}>"
-            )
+
             choice_view = SecondCaptainChoiceView(self.ctx, self.bot)
-            await self.ctx.send(
-                f"<@{self.bot.captain2['id']}>, choose draft type:", view=choice_view
-            )
+            choice_view.send_view()
         else:
             await self.ctx.send("Error: No game mode selected!")
 

--- a/views/map_vote_view.py
+++ b/views/map_vote_view.py
@@ -191,7 +191,7 @@ class MapVoteView(discord.ui.View):
                     return
 
             choice_view = SecondCaptainChoiceView(self.ctx, self.bot)
-            choice_view.send_view()
+            await choice_view.send_view()
         else:
             await self.ctx.send("Error: No game mode selected!")
 
@@ -290,7 +290,7 @@ class MapVoteView(discord.ui.View):
             self.vote_time_remaining -= 1
             if self.view_message:
                 await self.view_message.edit(
-                    content=f"Vote for the map to play ({self.vote_time_remaining}s):",
+                    content=f"Vote for the map to play: ({self.vote_time_remaining}s)",
                     view=self,
                 )
         if not self.voting_phase_ended:

--- a/views/mode_vote_view.py
+++ b/views/mode_vote_view.py
@@ -213,7 +213,7 @@ class ModeVoteView(discord.ui.View):
             self.vote_time_remaining -= 1
             if self.view_message:
                 await self.view_message.edit(
-                    content=f"Vote how teams should be chosen ({self.vote_time_remaining}s):",
+                    content=f"Vote how teams should be chosen: ({self.vote_time_remaining}s)",
                     view=self,
                 )
         if not self.voting_phase_ended:

--- a/views/mode_vote_view.py
+++ b/views/mode_vote_view.py
@@ -43,12 +43,13 @@ class ModeVoteView(discord.ui.View):
         self.timeout = False
         self.view_message = None
         self.vote_lock = asyncio.Lock()
+        self.vote_time_remaining = 25
 
         print("Starting new mode vote...")
 
     async def send_view(self):
         self.view_message = await self.ctx.send(
-            "Vote how teams should be chosen:", view=self
+            f"Vote how teams should be chosen: ({self.vote_time_remaining}s)", view=self
         )
 
     async def vote_callback(self, interaction: discord.Interaction, mode: str):
@@ -169,7 +170,9 @@ class ModeVoteView(discord.ui.View):
         for child in self.children:
             if isinstance(child, discord.ui.Button):
                 child.disabled = True
-        await self.view_message.edit(view=self)
+        await self.view_message.edit(
+            content="Vote how teams should be chosen:", view=self
+        )
 
         map_type_vote = MapTypeVoteView(self.ctx, self.bot)
         await map_type_vote.send_view()
@@ -203,7 +206,16 @@ class ModeVoteView(discord.ui.View):
         self.bot.team2 = team2
 
     async def timeout_timer(self):
-        await asyncio.sleep(25)
+        for _ in range(25):
+            await asyncio.sleep(1)
+            if self.voting_phase_ended:
+                return
+            self.vote_time_remaining -= 1
+            if self.view_message:
+                await self.view_message.edit(
+                    content=f"Vote how teams should be chosen ({self.vote_time_remaining}s):",
+                    view=self,
+                )
         if not self.voting_phase_ended:
             self.timeout = True
             await self.check_for_winner()

--- a/views/signup_view.py
+++ b/views/signup_view.py
@@ -25,6 +25,11 @@ class SignupView(discord.ui.View):
         self.signup_queue_task = asyncio.create_task(self.process_signup_queue())
         self.refresh_signup_task = asyncio.create_task(self.refresh_signup_message())
         self.channel_rename_task = asyncio.create_task(self.channel_rename_worker())
+        self.timeout_monitor_task = asyncio.create_task(self.monitor_queue())
+
+        # Activity tracking
+        self.last_activity_time = asyncio.get_event_loop().time()
+        self.empty_since_time = None
 
         # Setup Interaction Buttons
         self.sign_up_button = Button(
@@ -79,6 +84,9 @@ class SignupView(discord.ui.View):
         riot_names: list[str] = self.get_riot_names()
         print(f"{interaction.user.name} left the queue successfully")
 
+        # Update last activity
+        self.last_activity_time = asyncio.get_event_loop().time()
+
         # Edit the queue message and button label to reflect the new queue
         self.sign_up_button.label = f"Sign Up ({len(self.bot.queue)}/10)"
         await interaction.message.edit(
@@ -115,6 +123,70 @@ class SignupView(discord.ui.View):
         if self.signup_queue_task:
             self.signup_queue_task.cancel()
             self.signup_queue_task = None
+
+    async def monitor_queue(self):
+        try:
+            while True:
+                await asyncio.sleep(60)  # Check every minute
+                now = asyncio.get_event_loop().time()
+
+                if len(self.bot.queue) == 0:
+                    if self.empty_since_time is None:
+                        self.empty_since_time = now
+                    elif now - self.empty_since_time > 600:  # 10 minutes
+                        await self.cancel_signup(
+                            "Queue has been empty for more than 10 minutes."
+                        )
+                        break
+                else:
+                    self.empty_since_time = None
+
+                if now - self.last_activity_time > 7200:  # 120 minutes
+                    await self.cancel_signup(
+                        "Queue has been inactive for more than 120 minutes."
+                    )
+                    break
+        except asyncio.CancelledError:
+            pass
+
+    def cancel_timeout_monitor_task(self):
+        if self.timeout_monitor_task:
+            self.timeout_monitor_task.cancel()
+            self.timeout_monitor_task = None
+
+    async def cancel_signup(self, reason):
+        # Send message to original channel
+        try:
+            await self.ctx.send(f"Signup cancelled: {reason}")
+        except:
+            pass  # In case channel is deleted or something
+
+        # Clear variables
+        self.bot.signup_active = False
+        self.bot.queue = []
+        self.bot.captain1 = None
+        self.bot.captain2 = None
+        self.bot.team1 = []
+        self.bot.team2 = []
+        self.bot.chosen_mode = None
+        self.bot.selected_map = None
+
+        # Delete role and channel
+        try:
+            await self.bot.match_role.delete()
+        except:
+            pass
+        try:
+            await self.bot.match_channel.delete()
+        except:
+            pass
+
+        # Cleanup view
+        self.stop()
+        self.cancel_refresh_signup_task()
+        self.cancel_channel_rename_task()
+        self.cancel_signup_queue_task()
+        self.cancel_timeout_monitor_task()
 
     async def handle_signup(self, interaction: discord.Interaction):
         # Only allow up to 10 players in the queue
@@ -168,6 +240,9 @@ class SignupView(discord.ui.View):
         riot_names: list[str] = self.get_riot_names()
         print(f"{interaction.user.name} joined the queue successfully.")
 
+        # Update last activity
+        self.last_activity_time = asyncio.get_event_loop().time()
+
         # Add match role to the new player
         member = interaction.guild.get_member(
             interaction.user.id
@@ -220,6 +295,7 @@ class SignupView(discord.ui.View):
         self.cancel_refresh_signup_task()
         self.cancel_channel_rename_task()
         self.cancel_signup_queue_task()
+        self.cancel_timeout_monitor_task()
 
     async def refresh_signup_message(self):
         try:
@@ -326,6 +402,7 @@ class SignupView(discord.ui.View):
         self.cancel_channel_rename_task()
         self.cancel_refresh_signup_task()
         self.cancel_signup_queue_task()
+        self.cancel_timeout_monitor_task()
 
         self.ctx = None
         self.bot = None

--- a/views/signup_view.py
+++ b/views/signup_view.py
@@ -158,6 +158,7 @@ class SignupView(discord.ui.View):
         # Send message to original channel
         try:
             await self.ctx.send(f"Signup cancelled: {reason}")
+            print(f"Signup cancelled: {reason}")
         except:
             pass  # In case channel is deleted or something
 


### PR DESCRIPTION
 - [x] A version of the bot running this code has had at least one match reported successfully.

_Haven't done this in a while, so there will prolly be bugs. Feel free to report any REAL bugs with `!bug`_

Changes:
- The match setup process is slightly more descriptive, and votes that timeout now show the remaining time
- The `!report` function will immediately respond with a confirmation message
- The `!signup` queue will now auto-cancel if empty for 10 minutes or idle (nobody joins/leaves) for 2 hours)
  - Hopefully this will reduce the "oh shit I forgot I was in queue moments"
- The `!newseason` command now works and auto-assigns the SSR rank (in preparation for a season reset soon)
- Various security updates

Bugfixes:
- Removed/updated a bunch of bad season data
- Fixed a few ways that a queue could get stuck after timeout